### PR TITLE
Fix organization ID argument

### DIFF
--- a/src/common/cli.ts
+++ b/src/common/cli.ts
@@ -2,7 +2,7 @@ import { flag, number, option, optional, string } from "cmd-ts";
 
 export type OpenAIArgs = {
     apiKey: string;
-    organisationID?: string;
+    organizationId?: string;
 };
 
 export function getOpenAIOptions() {

--- a/src/common/completions.ts
+++ b/src/common/completions.ts
@@ -39,7 +39,7 @@ export class Completions {
             model: args.model ?? defaults.model,
             maxTokens: args.maxTokens ?? defaults.maxTokens,
             temperature: args.temperature ?? defaults.temperature,
-            openai: new OpenAI({ apiKey: args.apiKey, organization: args.organisationID }),
+            openai: new OpenAI({ apiKey: args.apiKey, organization: args.organizationId }),
         });
     }
 


### PR DESCRIPTION
## Summary
- align OpenAI arguments with CLI options to pass `organizationId`

## Testing
- `yarn test` *(fails: package missing in lockfile)*
- `yarn build` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_683d4cf10f20832d9de87d441b52c274